### PR TITLE
fix: fix image paste upload issue in Safari

### DIFF
--- a/packages/uploader/src/react/plugins/safari-paste.jsx
+++ b/packages/uploader/src/react/plugins/safari-paste.jsx
@@ -5,6 +5,7 @@ const isSafari = () => {
 };
 
 export class SafariPastePlugin extends UIPlugin {
+  originalHandlePasteOnBody = null
   constructor(uppy, opts) {
     super(uppy, opts);
     this.id = opts?.id || 'safari-paste';
@@ -13,7 +14,14 @@ export class SafariPastePlugin extends UIPlugin {
   
   onMount() {
     if (isSafari()) {
+      this.originalHandlePasteOnBody = this.parent.handlePasteOnBody
       this.parent.handlePasteOnBody = this.parent.handlePaste
+    }
+  }
+  
+  onUnmount() {
+    if (this.originalHandlePasteOnBody) {
+      this.parent.handlePasteOnBody = this.originalHandlePasteOnBody
     }
   }
 }

--- a/packages/uploader/src/react/plugins/safari-paste.jsx
+++ b/packages/uploader/src/react/plugins/safari-paste.jsx
@@ -1,0 +1,14 @@
+import { UIPlugin } from '@uppy/core';
+
+export class SafariPastePlugin extends UIPlugin {
+  constructor(uppy, opts) {
+    super(uppy, opts);
+    this.id = opts?.id || 'safari-paste';
+    this.type = 'editor';
+  }
+  
+  onMount() {
+    // if (safari) // todo
+    this.parent.handlePasteOnBody = this.parent.handlePaste
+  }
+}

--- a/packages/uploader/src/react/plugins/safari-paste.jsx
+++ b/packages/uploader/src/react/plugins/safari-paste.jsx
@@ -1,5 +1,9 @@
 import { UIPlugin } from '@uppy/core';
 
+const isSafari = () => {
+  return navigator.userAgent.includes('Safari') && !navigator.userAgent.includes('Chrome');
+};
+
 export class SafariPastePlugin extends UIPlugin {
   constructor(uppy, opts) {
     super(uppy, opts);
@@ -8,7 +12,8 @@ export class SafariPastePlugin extends UIPlugin {
   }
   
   onMount() {
-    // if (safari) // todo
-    this.parent.handlePasteOnBody = this.parent.handlePaste
+    if (isSafari()) {
+      this.parent.handlePasteOnBody = this.parent.handlePaste
+    }
   }
 }

--- a/packages/uploader/src/react/uploader.tsx
+++ b/packages/uploader/src/react/uploader.tsx
@@ -63,6 +63,8 @@ import PrepareUpload from './plugins/prepare-upload';
 import AIImage from './plugins/ai-image';
 // @ts-ignore
 import VirtualPlugin from './plugins/virtual-plugin';
+// @ts-ignore
+import { SafariPastePlugin } from './plugins/safari-paste';
 import { MEDIA_KIT_DID } from './constants';
 import cloneDeep from 'lodash/cloneDeep';
 import Typography from '@mui/material/Typography';
@@ -250,6 +252,10 @@ const getPluginList = (props: any) => {
           onShowPanel,
         };
       }),
+    {
+      id: 'safari-paste',
+      plugin: SafariPastePlugin,
+    }
   ].filter(Boolean);
 };
 


### PR DESCRIPTION
### 关联 Issue

<!-- 请用 fixes、closes、resolves、relates 这些关键词来关联 issue，原则上，所有 PR 都应该有关联 Issue -->

### 主要改动

<!--
  @example:
    1. 修复了 xxx
    2. 改进了 xxx
    3. 调整了 xxx
-->

修复 safari 中 paste 上传图片的问题

---

修复前, 

- 点击上传按钮 (弹窗) -> 立即粘贴图片 -> 可成功粘贴 ✅
- 点击上传按钮 (弹窗) -> 鼠标点击窗口元素 -> 粘贴图片 -> 无法成功粘贴 ❌

该修复主要修复第 2 种情况

### 界面截图

<!-- 如果改动的是跟 UI 相关的，不论是 CLI 还是 WEB 都应该截图 -->

### 测试计划

<!-- 如果本次变更没有自动化测试覆盖，你整理的测试用例集是什么？需要编写成 todo list 放到下面 -->

### 检查清单

- [x] 本次变更的兼容性测试覆盖了 Chrome
- [x] 本次变更的兼容性测试覆盖了 Safari
