### PR TITLE
fix(cloudflare): lazy-init S3 client to support dev mode without R2 creds

### DIFF
--- a/cloudflare/.gitignore
+++ b/cloudflare/.gitignore
@@ -7,6 +7,8 @@ public/
 # Wrangler
 .wrangler/
 .dev.vars
+wrangler.staging.toml
+wrangler.local.toml
 
 # Frontend
 frontend/node_modules/

--- a/cloudflare/src/routes/upload.ts
+++ b/cloudflare/src/routes/upload.ts
@@ -66,7 +66,9 @@ uploadRoutes.post('/uploads/presign', async (c) => {
 
   const db = c.get('db');
   const user = c.get('user');
-  const s3 = createS3Client(c.env);
+  // S3 client is only needed in non-dev mode (presigned direct-to-R2 upload).
+  // Lazy-construct inside the else branch below so dev mode (proxy-put) works
+  // without R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY secrets.
   const cleanExt = ext.replace(/^\./, '');
   const sessionId = crypto.randomUUID();
   const tempKey = `tmp/${crypto.randomUUID()}.${cleanExt}`;
@@ -128,6 +130,7 @@ uploadRoutes.post('/uploads/presign', async (c) => {
   if (isDev) {
     presignedUrl = `/api/uploads/proxy-put/${sessionId}`;
   } else {
+    const s3 = createS3Client(c.env);
     presignedUrl = await generatePresignedPutUrl(s3, c.env, tempKey, {
       contentType: mimetype,
     });


### PR DESCRIPTION
## Summary

- Fix `accessKeyId is a required option` crash on `/uploads/presign` when the worker is deployed with `ENVIRONMENT=development` but without `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` secrets set
- Lazy-construct the `AwsClient` only inside the `else` branch where presigned-direct-to-R2 upload actually needs it
- Add `wrangler.staging.toml` / `wrangler.local.toml` to `cloudflare/.gitignore` so per-environment configs don't get committed

## Background

Verified during a fresh CF Workers deploy of media-kit to a staging account that intentionally avoided creating R2 S3 API tokens (using \`ENVIRONMENT=development\` to keep upload mode = proxy-put). The dev-mode branch in \`upload.ts\` is supposed to skip the S3 path entirely, but \`createS3Client(c.env)\` was called unconditionally on line 69, causing \`aws4fetch\` to throw before reaching the dev/prod branch.

## Test plan

- [x] Deploy to staging with \`ENVIRONMENT=development\` and **no** R2 S3 secrets
- [x] Login via DID Connect, upload a small image through admin UI → success
- [ ] Verify multipart upload (>= 100MB) still works in non-dev mode (out of scope for this fix — multipart routes still need R2 creds)

## Known limitations not addressed by this PR

\`/uploads/multipart/part-url\` (line 356) and \`/uploads/multipart/status\` (line 443) still construct \`createS3Client\` unconditionally. They only trigger for files >= 100MB so dev-mode small-file uploads are unaffected. Suggest a follow-up PR to either lazy-init those too with a clear error, or add a \`proxy-put\` style fallback for multipart parts.