### PR TITLE
feat(cloudflare): support explicit APP_PID for shared-identity deployments

### DIFF
--- a/cloudflare/src/types.ts
+++ b/cloudflare/src/types.ts
@@ -31,6 +31,13 @@ export interface Env {
   APP_SK: string;    // 64-byte hex secret key — used to register & derive instance DID
   APP_NAME: string;
   APP_PID: string;   // Derived from APP_SK after registerApp; can also be set explicitly
+  /**
+   * Optional permanent signer key (ED25519 expanded form) for PSK delegation.
+   * When APP_PID is set explicitly and refers to a DID that differs from
+   * fromSecretKey(APP_SK).address, pass APP_PSK so blocklet-service stores
+   * the delegation pair and buildIdentity() returns the correct (appDid, appPid).
+   */
+  APP_PSK?: string;
   APP_PREFIX: string; // Mount prefix (e.g. '/media-kit') — empty or '/' means root
   // Auth Service (DID Connect via Service Binding)
   AUTH_SERVICE: {

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -99,11 +99,30 @@ async function ensureRegistered(env: Env): Promise<string> {
     return env.APP_PID || '';
   }
   try {
+    // When APP_PID is set explicitly we're in "shared identity" mode: this
+    // worker is part of a multi-component deployment (e.g. aigne-hub +
+    // payment-kit + media-kit all sharing one Blocklet Server identity) and
+    // another component owns the user-facing instance branding.
+    //   - Pass the explicit instanceDid so blocklet-service does NOT derive
+    //     a fresh DID from APP_SK and trigger a destructive migrateInstanceDid
+    //     against the sibling component.
+    //   - Pass APP_PSK (if set) so buildIdentity can return the correct
+    //     delegated (appDid, appPid) pair.
+    //   - Do NOT pass appName/appDescription so we don't overwrite the
+    //     owner component's branding every time media-kit boots.
+    // When APP_PID is unset (legacy single-tenant deploy) fall back to the
+    // old 'auto' behaviour with our own branding.
+    const isSharedIdentity = !!env.APP_PID;
     const result = await env.AUTH_SERVICE.registerApp({
-      instanceDid: 'auto',
+      instanceDid: env.APP_PID || 'auto',
       appSk: env.APP_SK,
-      appName: env.APP_NAME || 'Media Kit',
-      appDescription: 'Media asset management',
+      ...(env.APP_PSK ? { appPsk: env.APP_PSK } : {}),
+      ...(isSharedIdentity
+        ? {}
+        : {
+            appName: env.APP_NAME || 'Media Kit',
+            appDescription: 'Media asset management',
+          }),
     });
     registeredInstanceDid = result.instanceDid;
     console.log(`[media-kit] Registered as instance: ${registeredInstanceDid}`);


### PR DESCRIPTION
## Summary

Adds an opt-in "shared identity" mode so Media Kit can be deployed as a sibling CF Worker to other components (e.g. \`aigne-hub\`, \`payment-kit\`) that share a single Blocklet Server identity, without the three workers stomping on each other's \`blocklet-service\` instance registration.

- When \`env.APP_PID\` is set: pass it as the explicit \`instanceDid\` to \`AUTH_SERVICE.registerApp()\`, pass the new optional \`env.APP_PSK\` secret for PSK delegation, and skip \`appName\`/\`appDescription\` so we never overwrite the owner component's branding.
- When \`env.APP_PID\` is unset: fall back to the existing \`'auto'\` behaviour with Media Kit's own branding. Single-tenant deployments are unchanged.

## Background

In a shared-identity deployment, all sibling workers have the same \`BLOCKLET_APP_SK\` / \`BLOCKLET_APP_PSK\` secrets but each wants blocklet-service to treat them as components of one \`instance_did\` (the hub's permanent DID). The current \`instanceDid: 'auto'\` path causes two concrete problems:

1. **Destructive \`migrateInstanceDid\`**: \`registerApp()\` derives a fresh DID from \`APP_SK\`, then \`findInstancesByAppSk()\` matches the sibling component's existing row under a different DID, and blocklet-service UPDATEs all \`settings / memberships / security_rules / access_policies / access_keys / audit_logs / invitations\` from the original DID to the newly-derived one.
2. **\`app:name\` oscillation**: Media Kit always writes \`appName="Media Kit"\`, overwriting the owner's branding (e.g. \`"AIGNE Hub"\`). The sibling component's next \`registerApp()\` call flips it back. On every \`scheduled()\` run the login page's displayed app name flickers.

Both effects were observed live against a staging deployment where \`aigne-hub\` + \`payment-kit\` + \`media-kit\` share \`APP_PID=zNKWm5...\`. After this patch the shared row stays stable.

## Test plan

- [x] Deploy to staging with \`APP_PID\` set, \`APP_PSK\` secret set, and a sibling aigne-hub worker writing the owner branding
- [x] Verify \`blocklet-service\` D1 \`settings\` row under the shared \`instance_did\` retains \`app:name\` from the owner, not \`"Media Kit"\`
- [x] Verify \`app:psk\` row exists under the shared \`instance_did\` so \`buildIdentity()\` returns the correct delegated \`(appDid, appPid)\` pair
- [x] Verify that visiting the media-kit root path and triggering \`ensureRegistered()\` no longer causes \`migrateInstanceDid\` (row stays under the original \`instance_did\`)
- [ ] Verify single-tenant deploy (no \`APP_PID\` env var) still works unchanged

## Deployment notes

Add to your wrangler config for shared-identity mode:

\`\`\`toml
[vars]
APP_PID = "zNK..."  # explicit permanent DID of the logical instance
\`\`\`

\`\`\`bash
# Set the optional PSK secret (64-byte ED25519 expanded hex)
wrangler secret put APP_PSK
\`\`\`

Leave both unset for single-tenant deployments — existing behaviour is preserved.