### PR TITLE
feat(cloudflare): respect explicit APP_PID for umbrella-registered instances

### DIFF
--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -95,8 +95,15 @@ let registeredInstanceDid: string | null = null;
 
 async function ensureRegistered(env: Env): Promise<string> {
   if (registeredInstanceDid) return registeredInstanceDid;
+  // Explicit APP_PID wins — caller has already registered the instance out-of-band
+  // (e.g. staging-aigne-hub where the umbrella PID is pre-registered with SK+PSK).
+  // Skip auto-registration so we don't overwrite the canonical PID with the SK-derived DID.
+  if (env.APP_PID) {
+    registeredInstanceDid = env.APP_PID;
+    return registeredInstanceDid;
+  }
   if (!env.AUTH_SERVICE || !env.APP_SK) {
-    return env.APP_PID || '';
+    return '';
   }
   try {
     const result = await env.AUTH_SERVICE.registerApp({

--- a/cloudflare/wrangler.staging.toml
+++ b/cloudflare/wrangler.staging.toml
@@ -1,0 +1,46 @@
+name = "staging-aigne-hub-media-kit"
+main = "src/worker.ts"
+compatibility_date = "2024-12-01"
+compatibility_flags = ["nodejs_compat"]
+
+[assets]
+directory = "./public"
+not_found_handling = "none"
+html_handling = "none"
+binding = "ASSETS"
+
+[vars]
+ENVIRONMENT = "staging"
+APP_NAME = "AIGNE Hub Media Kit (staging)"
+APP_PID = "zNKWm5HBgaTLptTZBzjHo6PPFAp8X3n8pabY"
+APP_PREFIX = "/image-bin"
+MAX_UPLOAD_SIZE = "500MB"
+ALLOWED_FILE_TYPES = ".jpeg,.png,.gif,.svg,.webp,.bmp,.ico,.mp4,.mov,.webm"
+USE_AI_IMAGE = "false"
+AIGNE_HUB_URL = "https://hub.aigne.io"
+
+# Service Binding to DID Connect Auth Worker — staging blocklet-service
+[[services]]
+binding = "AUTH_SERVICE"
+service = "blocklet-service-staging"
+entrypoint = "BlockletServiceRPC"
+
+[[r2_buckets]]
+binding = "R2_UPLOADS"
+bucket_name = "staging-aigne-hub-media-kit"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "staging-aigne-hub-media-kit"
+database_id = "92773574-63d9-4ffa-a065-4ff5583b6289"
+migrations_dir = "migrations"
+
+[triggers]
+crons = ["0 * * * *"]
+
+# Secrets (already set on the deployed Worker; re-set only if rotated):
+#   APP_SK           — 64-byte hex; same umbrella SK as Payment Kit
+#   CF_ACCOUNT_ID    — Cloudflare account ID
+#   R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_ORIGIN_DOMAIN   (if using S3-compat)
+#   UNSPLASH_KEY, UNSPLASH_SECRET
+#   AIGNE_HUB_API_KEY


### PR DESCRIPTION
## Summary

`ensureRegistered` 里如果存在 `env.APP_PID`，直接把它作为 instance DID 返回，跳过 `AUTH_SERVICE.registerApp` 的自动注册逻辑。

**场景**：staging-aigne-hub-media-kit 这种使用 umbrella SK+PSK 预注册的实例，canonical PID 已经在外部注册好，不应该被请求期的 auto-register 用 SK 派生出来的 DID 覆盖。

## Behavior

| 环境 | `APP_PID` | `AUTH_SERVICE` + `APP_SK` | 结果 |
|---|---|---|---|
| 独立部署（原行为） | ❌ | ✅ | 调用 `registerApp` 自动注册，缓存返回的 instanceDid |
| umbrella 预注册（本 PR） | ✅ | ✅ | 直接返回 `APP_PID`，不调 `registerApp` |
| 兜底 | ❌ | ❌ | 返回空字符串（行为不变） |

## Test plan

- [ ] Deploy 到使用 umbrella PID 的 staging Worker
- [ ] 日志里不应出现 `[media-kit] Registered as instance: ...` — 走的是 explicit PID 短路分支
- [ ] `GET /api/status` 返回的 `instanceDid` 等于 `APP_PID`
- [ ] 独立部署环境（未设 `APP_PID`）auto-register 行为保持不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)